### PR TITLE
fix capitalization in code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To import the SDK in your project, use the following command:
 
 To initialize the SDK, you will need to specify the API Key, Access Token, and Environment Name of your stack.
 
-    const Stack = Contentstack.Stack("api_key","access_token","environment_name");
+    const Stack = contentstack.Stack("api_key","access_token","environment_name");
 
 #### For React Native
 


### PR DESCRIPTION
On line 34, the library is imported as `contentstack` (not `Contentstack`). This change syncs the case for the code sample on line 38.

```
const Stack = contentstack.Stack("api_key","access_token","environment_name");
```