### PR TITLE
refactor: :recycle: query function accepts queryObj

### DIFF
--- a/src/lib/entries.ts
+++ b/src/lib/entries.ts
@@ -179,7 +179,9 @@ export class Entries extends EntryQueryable {
    * const stack = contentstack.Stack({ apiKey: "apiKey", deliveryToken: "deliveryToken", environment: "environment" });
    * const result = await stack.contentType("contentTypeUid").entry().query();
    */
-  query() {
+  query(queryObj?: { [key: string]: any }) {
+    if (queryObj) return new Query(this._client, this._contentTypeUid, queryObj);
+
     return new Query(this._client, this._contentTypeUid);
   }
 }

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -4,11 +4,15 @@ import { BaseQueryParameters, QueryOperation, QueryOperator } from './types';
 export class Query extends BaseQuery {
   private _contentTypeUid?: string;
 
-  constructor(client: AxiosInstance, uid: string) {
+  constructor(client: AxiosInstance, uid: string, queryObj?: { [key: string]: any }) {
     super();
     this._client = client;
     this._contentTypeUid = uid;
     this._urlPath = `/content_types/${this._contentTypeUid}/entries`;
+
+    if (queryObj) {
+      this._parameters = { ...this._parameters, ...queryObj };
+    }
   }
 
   /**
@@ -133,27 +137,6 @@ export class Query extends BaseQuery {
       paramsList.push(queryItem._parameters);
     }
     this._parameters[queryType] = paramsList;
-
-    return this;
-  }
-
-  /**
-   * @method query
-   * @memberof Query
-   * @description Adds multiple query parameters to the query.
-   * @example
-   * import contentstack from '@contentstack/typescript'
-   *
-   * const stack = contentstack.Stack({ apiKey: "apiKey", deliveryToken: "deliveryToken", environment: "environment" });
-   * const query = stack.contentType("contentTypeUid").entry().query();
-   * const result = await query.query({'brand': {'$nin_query': {'title': 'Apple Inc.'}}}).find()
-   * // OR
-   * const asset = await stack.asset().query({'brand': {'$nin_query': {'title': 'Apple Inc.'}}}).find()
-   *
-   * @returns {Query}
-   */
-  query(queryObj: { [key: string]: any }): Query {
-    this._parameters = { ...this._parameters, ...queryObj };
 
     return this;
   }

--- a/test/api/asset.spec.ts
+++ b/test/api/asset.spec.ts
@@ -3,9 +3,12 @@
 import { Asset } from '../../src/lib/asset';
 import { stackInstance } from '../utils/stack-instance';
 import { TAsset } from './types';
+import dotenv from 'dotenv';
+
+dotenv.config();
 
 const stack = stackInstance();
-const assetUid = 'blt122ea52c5d4ddf19';
+const assetUid = process.env.ASSET_UID;
 describe('Asset API tests', () => {
   it('should check for asset is defined', async () => {
     const result = await makeAsset(assetUid).fetch<TAsset>();

--- a/test/api/contenttype.spec.ts
+++ b/test/api/contenttype.spec.ts
@@ -3,11 +3,14 @@
 import { ContentType } from '../../src/lib/content-type';
 import { stackInstance } from '../utils/stack-instance';
 import { TContentType, TEntry } from './types';
+import dotenv from 'dotenv';
+
+dotenv.config()
 
 const stack = stackInstance();
 describe('ContentType API test cases', () => {
   it('should give Entry instance when entry method is called with entryUid', async () => {
-    const result = await makeContentType('header').Entry('blt657fe7db362fea22').fetch<TEntry>();
+    const result = await makeContentType('author').Entry(process.env.ENTRY_UID as string).fetch<TEntry>();
     expect(result.entry).toBeDefined();
   });
   it('should check for content_types of the given contentTypeUid', async () => {

--- a/test/api/entry.spec.ts
+++ b/test/api/entry.spec.ts
@@ -4,10 +4,11 @@ import { stackInstance } from '../utils/stack-instance';
 import { TEntry } from './types';
 
 const stack = stackInstance();
+const entryUid = process.env.ENTRY_UID;
 
 describe('Entry API tests', () => {
   it('should check for entry is defined', async () => {
-    const result = await makeEntry('blt09f7d2d46afe6dc6').fetch<TEntry>();
+    const result = await makeEntry(entryUid).fetch<TEntry>();
     expect(result.entry).toBeDefined();
     expect(result.entry._version).toBeDefined();
     expect(result.entry.locale).toEqual('en-us');
@@ -21,20 +22,20 @@ describe('Entry API tests', () => {
       bio: string;
       age: string;
     }
-    const result = await makeEntry('blt09f7d2d46afe6dc6').fetch<MyEntry>();
+    const result = await makeEntry(entryUid).fetch<MyEntry>();
 
     console.log('🚀 ~ file: entry.spec.ts:25 ~ it ~ result:', result);
     expect(result.entry).toBeDefined();
   });
   it('should check for include branch', async () => {
-    const result = await makeEntry('blt09f7d2d46afe6dc6').includeBranch().fetch<TEntry>();
+    const result = await makeEntry(entryUid).includeBranch().fetch<TEntry>();
     expect(result.entry._branch).not.toEqual(undefined);
     expect(result.entry.uid).toBeDefined();
     expect(result.entry.created_by).toBeDefined();
     expect(result.entry.updated_by).toBeDefined();
   });
   it('should check for locale', async () => {
-    const result = await makeEntry('blt09f7d2d46afe6dc6').locale('fr-fr').fetch<TEntry>();
+    const result = await makeEntry(entryUid).locale('fr-fr').fetch<TEntry>();
     expect(result.entry).toBeDefined();
     expect(result.entry._version).toBeDefined();
     expect(result.entry.publish_details.locale).toEqual('fr-fr');
@@ -43,7 +44,7 @@ describe('Entry API tests', () => {
     expect(result.entry.updated_by).toBeDefined();
   });
   it('should check for include fallback', async () => {
-    const result = await makeEntry('blt09f7d2d46afe6dc6').includeFallback().fetch<TEntry>();
+    const result = await makeEntry(entryUid).includeFallback().fetch<TEntry>();
     expect(result.entry).toBeDefined();
     expect(result.entry._version).toBeDefined();
     expect(result.entry.locale).toEqual('en-us');

--- a/test/api/query.spec.ts
+++ b/test/api/query.spec.ts
@@ -3,6 +3,8 @@ import { stackInstance } from '../utils/stack-instance';
 import { TEntries } from './types';
 
 const stack = stackInstance();
+const entryUid:string = process.env.ENTRY_UID || '';
+const userUid:string = process.env.USER_UID || '';
 describe('Query API tests', () => {
   it('should add a where filter to the query parameters', async () => {
     const query = await makeQuery('blog_post')
@@ -20,9 +22,9 @@ describe('Query API tests', () => {
   });
   it('should add a where-in filter to the query parameters', async () => {
     const query = await makeQuery('blog_post')
-      .whereIn('author', makeQuery('author').where('uid', QueryOperation.EQUALS, 'blt09f7d2d46afe6dc6'))
+      .whereIn('author', makeQuery('author').where('uid', QueryOperation.EQUALS, entryUid))
       .find<TEntries>();
-    expect(query.entries[0].author[0].uid).toEqual('blt09f7d2d46afe6dc6');
+    expect(query.entries[0].author[0].uid).toEqual(entryUid);
     expect(query.entries[0].title).toBeDefined();
     expect(query.entries[0].url).toBeDefined();
     expect(query.entries[0]._version).toBeDefined();
@@ -30,9 +32,9 @@ describe('Query API tests', () => {
   });
   it('should add a whereNotIn filter to the query parameters', async () => {
     const query = await makeQuery('blog_post')
-      .whereNotIn('author', makeQuery('author').where('uid', QueryOperation.EQUALS, 'blt09f7d2d46afe6dc6'))
+      .whereNotIn('author', makeQuery('author').where('uid', QueryOperation.EQUALS, entryUid))
       .find<TEntries>();
-    expect(query.entries[0].author[0]).not.toEqual('blt09f7d2d46afe6dc6');
+    expect(query.entries[0].author[0]).not.toEqual(entryUid);
     expect(query.entries[0].title).toBeDefined();
     expect(query.entries[0].url).toBeDefined();
     expect(query.entries[0]._version).toBeDefined();
@@ -40,10 +42,10 @@ describe('Query API tests', () => {
   });
   it('should add a query operator to the query parameters', async () => {
     const query1 = makeQuery('blog_post').where('locale', QueryOperation.EQUALS, 'en-us');
-    const query2 = makeQuery('blog_post').where('created_by', QueryOperation.EQUALS, 'blt79e6de1c5230a991');
+    const query2 = makeQuery('blog_post').where('created_by', QueryOperation.EQUALS, userUid);
     const query = await makeQuery('blog_post').queryOperator(QueryOperator.AND, query1, query2).find<TEntries>();
     expect(query.entries[0].locale).toEqual('en-us');
-    expect(query.entries[0].created_by).toEqual('blt79e6de1c5230a991');
+    expect(query.entries[0].created_by).toEqual(userUid);
     expect(query.entries[0].title).not.toEqual(undefined);
     expect(query.entries[0].url).not.toEqual(undefined);
     expect(query.entries[0]._version).not.toEqual(undefined);

--- a/test/api/query.spec.ts
+++ b/test/api/query.spec.ts
@@ -14,6 +14,10 @@ describe('Query API tests', () => {
     const query = await makeQuery('blog_post').where('_version', QueryOperation.IS_LESS_THAN, 3).find<TEntries>();
     expect(query.entries[0].title).toEqual('The future of business with AI');
   });
+  it('should add a where filter to the query parameters when object is passed to query method', async () => {
+    const query = await makeQuery('blog_post', {'_version': { '$lt': 3 }}).find<TEntries>();
+    expect(query.entries[0].title).toEqual('The future of business with AI');
+  });
   it('should add a where-in filter to the query parameters', async () => {
     const query = await makeQuery('blog_post')
       .whereIn('author', makeQuery('author').where('uid', QueryOperation.EQUALS, 'blt09f7d2d46afe6dc6'))
@@ -46,8 +50,9 @@ describe('Query API tests', () => {
     expect(query.entries[0].publish_details).not.toEqual(undefined);
   });
 });
-function makeQuery(ctUid: string) {
-  const query = stack.ContentType(ctUid).Entry().query();
+function makeQuery(ctUid: string, queryObj?: { [key: string]: any }) {
+  const entryInstance = stack.ContentType(ctUid).Entry();
 
-  return query;
+  if (queryObj) return entryInstance.query(queryObj);
+  return entryInstance.query();
 }

--- a/test/unit/image-transform.spec.ts
+++ b/test/unit/image-transform.spec.ts
@@ -121,7 +121,7 @@ describe('ImageTransform class', () => {
   });
 
   it('should return valid object when overlay method is called with valid params', () => {
-    const overlayImgURL = '/v3/assets/blteae40eb499811073/bltb21dacdd20d0e24c/59e0c401462a293417405f34/circle.png';
+    const overlayImgURL = '/v3/assets/circle.png';
     expect(getBuild(new ImageTransform().overlay({ relativeURL: overlayImgURL }))).toEqual({ overlay: overlayImgURL });
     expect(getBuild(new ImageTransform().overlay({ relativeURL: overlayImgURL, align: OverlayAlign.BOTTOM }))).toEqual({
       overlay: overlayImgURL,

--- a/test/unit/query.spec.ts
+++ b/test/unit/query.spec.ts
@@ -20,11 +20,8 @@ describe('Query class', () => {
   });
 
   it('should set a parameter correctly', () => {
-    query.query({ key1: 'value1' });
-    expect(query._parameters).toEqual({ key1: 'value1' });
-
-    query.query({ key2: 'value2' });
-    expect(query._parameters).toEqual({ key1: 'value1', key2: 'value2' });
+    const _query = getQueryObject(client, 'contentTypeUid', { key1: 'value1' })
+    expect(_query._parameters).toEqual({ key1: 'value1' });
   });
 
   it('should add an equality parameter to _parameters when queryOperation is EQUALS', () => {
@@ -92,6 +89,8 @@ describe('Query class', () => {
   });
 });
 
-function getQueryObject(client: AxiosInstance, uid: string) {
+function getQueryObject(client: AxiosInstance, uid: string, queryObj?: { [key: string]: any }) {
+  if (queryObj) return new Query(client, uid, queryObj);
+
   return new Query(client, uid);
 }


### PR DESCRIPTION
Query function earlier had another query function to accept query Object.
Refactored it to base query function. 