### PR TITLE
Fixes: getQuery function and fetch functions

### DIFF
--- a/src/lib/asset-query.ts
+++ b/src/lib/asset-query.ts
@@ -1,5 +1,5 @@
 import { BaseQuery } from './base-query';
-import { AxiosInstance, getData } from '@contentstack/core';
+import { AxiosInstance } from '@contentstack/core';
 
 export class AssetQuery extends BaseQuery {
   constructor(client: AxiosInstance) {

--- a/src/lib/asset.ts
+++ b/src/lib/asset.ts
@@ -1,8 +1,5 @@
 import { AxiosInstance, getData } from '@contentstack/core';
 
-interface AssetResponse<T> {
-  asset: T;
-}
 export class Asset {
   private _client: AxiosInstance;
   private _urlPath: string;
@@ -143,9 +140,11 @@ export class Asset {
    * const stack = contentstack.Stack({ apiKey: "apiKey", deliveryToken: "deliveryToken", environment: "environment" });
    * const result = await stack.asset('asset_uid').fetch();
    */
-  async fetch<T>(): Promise<AssetResponse<T>> {
+  async fetch<T>(): Promise<T> {
     const response = await getData(this._client, this._urlPath, this._queryParams);
 
-    return response as AssetResponse<T>;
+    if (response.asset) return response.asset as T;
+
+    return response;
   }
 }

--- a/src/lib/base-query.ts
+++ b/src/lib/base-query.ts
@@ -1,5 +1,6 @@
 import { AxiosInstance, getData } from '@contentstack/core';
 import { Pagination } from './pagination';
+import { FindResponse } from './types';
 
 export class BaseQuery extends Pagination {
   _parameters: { [key: string]: any } = {}; // Params of query class ?query={}
@@ -154,12 +155,12 @@ export class BaseQuery extends Pagination {
    * const result = await stack.asset(asset_uid).fetch();
    */
 
-  async find<T>(): Promise<T> {
+  async find<T>(): Promise<FindResponse<T>> {
     let requestParams: { [key: string]: any } = this._queryParams;
     if (Object.keys(this._parameters)) requestParams = { ...this._queryParams, query: { ...this._parameters } };
 
     const response = await getData(this._client, this._urlPath, requestParams);
 
-    return response as T;
+    return response as FindResponse<T>;
   }
 }

--- a/src/lib/content-type.ts
+++ b/src/lib/content-type.ts
@@ -48,9 +48,11 @@ export class ContentType {
    * const stack = contentstack.Stack({ apiKey: "apiKey", deliveryToken: "deliveryToken", environment: "environment" });
    * const result = await stack.contentType(asset_uid).fetch();
    */
-  async fetch<T>(): Promise<ContentTypeResponse<T>> {
+  async fetch<T>(): Promise<T> {
     const response = await getData(this._client, this._urlPath);
 
-    return response as ContentTypeResponse<T>;
+    if (response.content_type) return response.content_type as T;
+
+    return response;
   }
 }

--- a/src/lib/contenttype-query.ts
+++ b/src/lib/contenttype-query.ts
@@ -1,4 +1,5 @@
 import { AxiosInstance, getData } from '@contentstack/core';
+import { FindResponse } from './types';
 
 export class ContentTypeQuery {
   private _client: AxiosInstance;
@@ -38,9 +39,9 @@ export class ContentTypeQuery {
    * const contentTypeQuery = stack.contentType();
    * const result = await contentTypeQuery.find();
    */
-  async find<T>(): Promise<T> {
+  async find<T>(): Promise<FindResponse<T>> {
     const response = await getData(this._client, this._urlPath, this._queryParams);
 
-    return response as T;
+    return response as FindResponse<T>;
   }
 }

--- a/src/lib/entry.ts
+++ b/src/lib/entry.ts
@@ -130,9 +130,11 @@ export class Entry {
    * const stack = contentstack.Stack({ apiKey: "apiKey", deliveryToken: "deliveryToken", environment: "environment" });
    * const result = await stack.contentType(contentType_uid).entry(entry_uid).fetch();
    */
-  async fetch<T>(): Promise<EntryResponse<T>> {
+  async fetch<T>(): Promise<T> {
     const response = await getData(this._client, this._urlPath, this._queryParams);
 
-    return response as EntryResponse<T>;
+    if (response.entry) return response.entry as T;
+
+    return response;
   }
 }

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -161,9 +161,7 @@ export class Query extends BaseQuery {
    *
    * @returns {Query}
    */
-  getQuery(queryObj: { [key: string]: any }): Query {
-    this._parameters = { ...this._parameters, ...queryObj };
-
-    return this;
+  getQuery(): { [key: string]: any } {
+    return this._parameters;
   }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -244,19 +244,13 @@ export interface BaseContentType {
   last_activity: any;
   maintain_revisions: boolean;
   _version: number;
+  schema: any;
 }
 
-export interface FindEntry<T> {
-  entries: T[];
-  count?: number;
-}
-
-export interface FindContentType<T> {
-  content_types: T[];
-  count?: number;
-}
-
-export interface FindAsset<T> {
-  assets: T[];
-  count?: number;
+export interface FindResponse<T> {
+  entries?: T[];
+  content_types?: T[];
+  assets?: T[];
+  global_fields?: T[];
+  count?: number
 }

--- a/test/api/asset.spec.ts
+++ b/test/api/asset.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 /* eslint-disable promise/always-return */
+import { BaseAsset } from 'src';
 import { Asset } from '../../src/lib/asset';
 import { stackInstance } from '../utils/stack-instance';
 import { TAsset } from './types';
@@ -11,81 +12,94 @@ const stack = stackInstance();
 const assetUid = process.env.ASSET_UID;
 describe('Asset API tests', () => {
   it('should check for asset is defined', async () => {
-    const result = await makeAsset(assetUid).fetch<TAsset>();
-    expect(result.asset).toBeDefined();
-    expect(result.asset._version).toBeDefined();
-    expect(result.asset.uid).toBeDefined();
-    expect(result.asset.url).toBeDefined();
-    expect(result.asset.filename).toBeDefined();
-    expect(result.asset.created_by).toBeDefined();
-    expect(result.asset.updated_by).toBeDefined();
+    const result = await makeAsset(assetUid).fetch<BaseAsset>();
+    expect(result).toBeDefined();
+    expect(result._version).toBeDefined();
+    expect(result.uid).toBeDefined();
+    expect(result.url).toBeDefined();
+    expect(result.filename).toBeDefined();
+    expect(result.created_by).toBeDefined();
+    expect(result.updated_by).toBeDefined();
   });
   it('should check for include dimension', async () => {
-    const result = await makeAsset(assetUid).includeDimension().fetch<TAsset>();
-    expect(result.asset.dimension).not.toEqual(undefined);
-    expect(result.asset._version).toBeDefined();
-    expect(result.asset.uid).toBeDefined();
-    expect(result.asset.url).toBeDefined();
-    expect(result.asset.filename).toBeDefined();
-    expect(result.asset.created_by).toBeDefined();
-    expect(result.asset.updated_by).toBeDefined();
+    interface AssetWithDimension extends BaseAsset {
+      dimension: {
+        height: number;
+        width: number;
+      }
+    }
+    const result = await makeAsset(assetUid).includeDimension().fetch<AssetWithDimension>();
+    expect(result.dimension).not.toEqual(undefined);
+    expect(result._version).toBeDefined();
+    expect(result.uid).toBeDefined();
+    expect(result.url).toBeDefined();
+    expect(result.filename).toBeDefined();
+    expect(result.created_by).toBeDefined();
+    expect(result.updated_by).toBeDefined();
   });
   it('should check for include branch', async () => {
-    const result = await makeAsset(assetUid).includeBranch().fetch<TAsset>();
-    expect(result.asset._branch).not.toEqual(undefined);
-    expect(result.asset._version).toBeDefined();
-    expect(result.asset.uid).toBeDefined();
-    expect(result.asset.url).toBeDefined();
-    expect(result.asset.filename).toBeDefined();
-    expect(result.asset.created_by).toBeDefined();
-    expect(result.asset.updated_by).toBeDefined();
+    interface AssetWithBranch extends BaseAsset {
+      _branch: string;
+    }
+    const result = await makeAsset(assetUid).includeBranch().fetch<AssetWithBranch>();
+    expect(result._branch).not.toEqual(undefined);
+    expect(result._version).toBeDefined();
+    expect(result.uid).toBeDefined();
+    expect(result.url).toBeDefined();
+    expect(result.filename).toBeDefined();
+    expect(result.created_by).toBeDefined();
+    expect(result.updated_by).toBeDefined();
   });
   it('should check for include fallback', async () => {
-    const result = await makeAsset(assetUid).includeFallback().fetch<TAsset>();
-    expect(result.asset._version).toBeDefined();
-    expect(result.asset.publish_details.locale).toEqual('en-us');
-    expect(result.asset.uid).toBeDefined();
-    expect(result.asset.url).toBeDefined();
-    expect(result.asset.filename).toBeDefined();
-    expect(result.asset.created_by).toBeDefined();
-    expect(result.asset.updated_by).toBeDefined();
+    const result = await makeAsset(assetUid).includeFallback().fetch<BaseAsset>();
+    expect(result._version).toBeDefined();
+    expect(result.publish_details?.locale).toEqual('en-us');
+    expect(result.uid).toBeDefined();
+    expect(result.url).toBeDefined();
+    expect(result.filename).toBeDefined();
+    expect(result.created_by).toBeDefined();
+    expect(result.updated_by).toBeDefined();
   });
 
   it('should check for relative urls', async () => {
-    const result = await makeAsset(assetUid).relativeUrls().fetch<TAsset>();
-    expect(result.asset.url).not.toEqual(undefined);
-    expect(result.asset._version).toBeDefined();
-    expect(result.asset.uid).toBeDefined();
-    expect(result.asset.url).toBeDefined();
-    expect(result.asset.filename).toBeDefined();
-    expect(result.asset.created_by).toBeDefined();
-    expect(result.asset.updated_by).toBeDefined();
+    const result = await makeAsset(assetUid).relativeUrls().fetch<BaseAsset>();
+    expect(result.url).not.toEqual(undefined);
+    expect(result._version).toBeDefined();
+    expect(result.uid).toBeDefined();
+    expect(result.url).toBeDefined();
+    expect(result.filename).toBeDefined();
+    expect(result.created_by).toBeDefined();
+    expect(result.updated_by).toBeDefined();
   });
   it('should check for version of asset', async () => {
-    const result = await makeAsset(assetUid).version(1).fetch<TAsset>();
-    expect(result.asset._version).toEqual(1);
-    expect(result.asset.uid).toBeDefined();
-    expect(result.asset.url).toBeDefined();
-    expect(result.asset.filename).toBeDefined();
-    expect(result.asset.created_by).toBeDefined();
-    expect(result.asset.updated_by).toBeDefined();
+    const result = await makeAsset(assetUid).version(1).fetch<BaseAsset>();
+    expect(result._version).toEqual(1);
+    expect(result.uid).toBeDefined();
+    expect(result.url).toBeDefined();
+    expect(result.filename).toBeDefined();
+    expect(result.created_by).toBeDefined();
+    expect(result.updated_by).toBeDefined();
   });
   it('should check for include metadata', async () => {
-    const result = await makeAsset(assetUid).includeMetadata().fetch<TAsset>();
-    expect(result.asset._metadata).not.toEqual(undefined);
-    expect(result.asset._version).toBeDefined();
-    expect(result.asset.uid).toBeDefined();
-    expect(result.asset.content_type).toBeDefined();
-    expect(result.asset.created_by).toBeDefined();
-    expect(result.asset.updated_by).toBeDefined();
+
+    interface AssetWithMetadata extends BaseAsset {
+      _metadata: string;
+    }
+    const result = await makeAsset(assetUid).includeMetadata().fetch<AssetWithMetadata>();
+    expect(result._metadata).not.toEqual(undefined);
+    expect(result._version).toBeDefined();
+    expect(result.uid).toBeDefined();
+    expect(result.content_type).toBeDefined();
+    expect(result.created_by).toBeDefined();
+    expect(result.updated_by).toBeDefined();
   });
   it('should check for locale', async () => {
-    const result = await makeAsset(assetUid).locale('en-us').fetch<TAsset>();
-    expect(result.asset._version).toEqual(1);
-    expect(result.asset.uid).toBeDefined();
-    expect(result.asset.content_type).toBeDefined();
-    expect(result.asset.created_by).toBeDefined();
-    expect(result.asset.updated_by).toBeDefined();
+    const result = await makeAsset(assetUid).locale('en-us').fetch<BaseAsset>();
+    expect(result._version).toEqual(1);
+    expect(result.uid).toBeDefined();
+    expect(result.content_type).toBeDefined();
+    expect(result.created_by).toBeDefined();
+    expect(result.updated_by).toBeDefined();
   });
 });
 function makeAsset(uid = ''): Asset {

--- a/test/api/contenttype.spec.ts
+++ b/test/api/contenttype.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 /* eslint-disable promise/always-return */
+import { BaseContentType, BaseEntry } from 'src';
 import { ContentType } from '../../src/lib/content-type';
 import { stackInstance } from '../utils/stack-instance';
 import { TContentType, TEntry } from './types';
@@ -11,18 +12,18 @@ const stack = stackInstance();
 describe('ContentType API test cases', () => {
   it('should give Entry instance when entry method is called with entryUid', async () => {
     const result = await makeContentType('author').Entry(process.env.ENTRY_UID as string).fetch<TEntry>();
-    expect(result.entry).toBeDefined();
+    expect(result).toBeDefined();
   });
   it('should check for content_types of the given contentTypeUid', async () => {
     const result = await makeContentType('header').fetch<TContentType>();
-    expect(result.content_type).toBeDefined();
-    expect(result.content_type._version).toBeDefined();
-    expect(result.content_type.title).toBeDefined();
-    expect(result.content_type.description).toBeDefined();
-    expect(result.content_type.uid).toBeDefined();
-    expect(result.content_type.created_at).toBeDefined();
-    expect(result.content_type.updated_at).toBeDefined();
-    expect(result.content_type.schema).toBeDefined();
+    expect(result).toBeDefined();
+    expect(result._version).toBeDefined();
+    expect(result.title).toBeDefined();
+    expect(result.description).toBeDefined();
+    expect(result.uid).toBeDefined();
+    expect(result.created_at).toBeDefined();
+    expect(result.updated_at).toBeDefined();
+    expect(result.schema).toBeDefined();
   });
 });
 function makeContentType(uid = ''): ContentType {

--- a/test/api/entry.spec.ts
+++ b/test/api/entry.spec.ts
@@ -9,12 +9,12 @@ const entryUid = process.env.ENTRY_UID;
 describe('Entry API tests', () => {
   it('should check for entry is defined', async () => {
     const result = await makeEntry(entryUid).fetch<TEntry>();
-    expect(result.entry).toBeDefined();
-    expect(result.entry._version).toBeDefined();
-    expect(result.entry.locale).toEqual('en-us');
-    expect(result.entry.uid).toBeDefined();
-    expect(result.entry.created_by).toBeDefined();
-    expect(result.entry.updated_by).toBeDefined();
+    expect(result).toBeDefined();
+    expect(result._version).toBeDefined();
+    expect(result.locale).toEqual('en-us');
+    expect(result.uid).toBeDefined();
+    expect(result.created_by).toBeDefined();
+    expect(result.updated_by).toBeDefined();
   });
 
   it('should check for entry is defined with BaseEntry', async () => {
@@ -23,34 +23,32 @@ describe('Entry API tests', () => {
       age: string;
     }
     const result = await makeEntry(entryUid).fetch<MyEntry>();
-
-    console.log('🚀 ~ file: entry.spec.ts:25 ~ it ~ result:', result);
-    expect(result.entry).toBeDefined();
+    expect(result).toBeDefined();
   });
   it('should check for include branch', async () => {
     const result = await makeEntry(entryUid).includeBranch().fetch<TEntry>();
-    expect(result.entry._branch).not.toEqual(undefined);
-    expect(result.entry.uid).toBeDefined();
-    expect(result.entry.created_by).toBeDefined();
-    expect(result.entry.updated_by).toBeDefined();
+    expect(result._branch).not.toEqual(undefined);
+    expect(result.uid).toBeDefined();
+    expect(result.created_by).toBeDefined();
+    expect(result.updated_by).toBeDefined();
   });
   it('should check for locale', async () => {
     const result = await makeEntry(entryUid).locale('fr-fr').fetch<TEntry>();
-    expect(result.entry).toBeDefined();
-    expect(result.entry._version).toBeDefined();
-    expect(result.entry.publish_details.locale).toEqual('fr-fr');
-    expect(result.entry.uid).toBeDefined();
-    expect(result.entry.created_by).toBeDefined();
-    expect(result.entry.updated_by).toBeDefined();
+    expect(result).toBeDefined();
+    expect(result._version).toBeDefined();
+    expect(result.publish_details.locale).toEqual('fr-fr');
+    expect(result.uid).toBeDefined();
+    expect(result.created_by).toBeDefined();
+    expect(result.updated_by).toBeDefined();
   });
   it('should check for include fallback', async () => {
     const result = await makeEntry(entryUid).includeFallback().fetch<TEntry>();
-    expect(result.entry).toBeDefined();
-    expect(result.entry._version).toBeDefined();
-    expect(result.entry.locale).toEqual('en-us');
-    expect(result.entry.uid).toBeDefined();
-    expect(result.entry.created_by).toBeDefined();
-    expect(result.entry.updated_by).toBeDefined();
+    expect(result).toBeDefined();
+    expect(result._version).toBeDefined();
+    expect(result.locale).toEqual('en-us');
+    expect(result.uid).toBeDefined();
+    expect(result.created_by).toBeDefined();
+    expect(result.updated_by).toBeDefined();
   });
 });
 function makeEntry(uid = ''): Entry {

--- a/test/unit/asset.spec.ts
+++ b/test/unit/asset.spec.ts
@@ -57,6 +57,6 @@ describe('Asset class', () => {
   it('should add "fetch" in _queryParams when fetch method is called', async () => {
     mockClient.onGet(`/assets/assetUid`).reply(200, assetFetchDataMock);
     const returnedValue = await asset.fetch();
-    expect(returnedValue).toEqual(assetFetchDataMock);
+    expect(returnedValue).toEqual(assetFetchDataMock.asset);
   });
 });

--- a/test/unit/base-query.spec.ts
+++ b/test/unit/base-query.spec.ts
@@ -1,5 +1,4 @@
 import { BaseQuery } from '../../src/lib/base-query';
-import { QueryOperation } from '../../src/lib/types';
 
 describe('BaseQuery class', () => {
   let baseQuery: BaseQuery;

--- a/test/unit/contenttype.spec.ts
+++ b/test/unit/contenttype.spec.ts
@@ -38,6 +38,6 @@ describe('ContentType class', () => {
     mockClient.onGet('/content_types/contentTypeUid').reply(200, contentTypeResponseMock);
 
     const response = await contentType.fetch();
-    expect(response).toEqual(contentTypeResponseMock);
+    expect(response).toEqual(contentTypeResponseMock.content_type);
   });
 });

--- a/test/unit/entries.spec.ts
+++ b/test/unit/entries.spec.ts
@@ -94,8 +94,8 @@ describe('Entries class', () => {
     });
 
     test('CT Taxonomy Query: Get entries with any term ($in)', () => {
-      const query = entry.query().where("taxonomies.taxonomy_uid", QueryOperation.INCLUDES, ["term_uid1", "term_uid2"]).getQuery({});
-      expect(query._parameters).toEqual({"taxonomies.taxonomy_uid": { "$in": ["term_uid1", "term_uid2"] }});
+      const query = entry.query().where("taxonomies.taxonomy_uid", QueryOperation.INCLUDES, ["term_uid1", "term_uid2"]).getQuery();
+      expect(query).toEqual({"taxonomies.taxonomy_uid": { "$in": ["term_uid1", "term_uid2"] }});
     });
 
     test('CT Taxonomy Query: Get entries with any term ($or)', () => {

--- a/test/unit/entry.spec.ts
+++ b/test/unit/entry.spec.ts
@@ -58,6 +58,7 @@ describe('Entry class', () => {
   it('should get the API response when fetch method is called', async () => {
     mockClient.onGet(`/content_types/contentTypeUid/entries/entryUid`).reply(200, entryFetchMock);
     const returnedValue = await entry.fetch();
-    expect(returnedValue).toEqual(entryFetchMock);
+    
+    expect(returnedValue).toEqual(entryFetchMock.entry);
   });
 });

--- a/test/unit/taxonomy-query.spec.ts
+++ b/test/unit/taxonomy-query.spec.ts
@@ -21,13 +21,13 @@ describe("Taxonomy-query class", () => {
     })
 
     it('Taxonomy Query: Get entries with one term', () => {
-        const query = taxonomyQuery.where("taxonomies.taxonomy_uid", QueryOperation.EQUALS, "term_uid").getQuery({});
-        expect(query._parameters).toEqual({"taxonomies.taxonomy_uid": "term_uid"});
+        const query = taxonomyQuery.where("taxonomies.taxonomy_uid", QueryOperation.EQUALS, "term_uid").getQuery();
+        expect(query).toEqual({"taxonomies.taxonomy_uid": "term_uid"});
     });
 
     it('Taxonomy Query: Get entries with any term ($in)', () => {
-        const query = taxonomyQuery.where("taxonomies.taxonomy_uid", QueryOperation.INCLUDES, ["term_uid1", "term_uid2"]).getQuery({});
-        expect(query._parameters).toEqual({"taxonomies.taxonomy_uid": { "$in": ["term_uid1", "term_uid2"] }});
+        const query = taxonomyQuery.where("taxonomies.taxonomy_uid", QueryOperation.INCLUDES, ["term_uid1", "term_uid2"]).getQuery();
+        expect(query).toEqual({"taxonomies.taxonomy_uid": { "$in": ["term_uid1", "term_uid2"] }});
     });
 
     it('Taxonomy Query: Get entries with any term ($or)', () => {


### PR DESCRIPTION
- fetch function to directly give entry/asset/ct object instead of enclosing in another object. 
- getQuery function fixed to return query object. 