### PR TITLE
feat: :sparkles: Timeline Preview support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Change log
 
+### Version: 3.20.0
+#### Date:  May-31-2024
+##### Enhanncement:
+ - Adds Timeline Preview changes
+
 ### Version: 3.19.3
 #### Date:  May-17-2024
 ##### Enhanncement:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contentstack",
-  "version": "3.19.3",
+  "version": "3.20.0",
   "description": "Contentstack Javascript SDK",
   "homepage": "https://www.contentstack.com/",
   "author": {

--- a/src/core/lib/utils.js
+++ b/src/core/lib/utils.js
@@ -91,7 +91,7 @@ export function merge(target, source) {
 
 // return true if process is running in browser else false
 export function isBrowser() {
-    return (typeof window !== "undefined" && typeof process === "object" && process.title === "browser");
+    return (typeof window !== "undefined");
 }
 
 

--- a/src/core/stack.js
+++ b/src/core/stack.js
@@ -111,6 +111,7 @@ export default class Stack {
                     };
                     if (typeof stack_arguments[0].live_preview == "object") {
                         this.live_preview =  Utils.mergeDeep(this.config.live_preview , stack_arguments[0].live_preview)
+                        this.setLivePreviewTimelinePreviewForClient()
                     }
                     if (typeof stack_arguments[0].branch === "string" && stack_arguments[0].branch !== undefined) {
                         this.headers.branch = stack_arguments[0].branch
@@ -249,12 +250,33 @@ export default class Stack {
         return this;
     }
 
+    setLivePreviewTimelinePreviewForClient() {
+        if (Utils.isBrowser()){
+            const params = new URL(document.location.toString()).searchParams;
+            if (params.has('live_preview')) {
+                this.live_preview.live_preview = params.get('live_preview');
+            }
+            if (params.has('release_id')) {
+                this.headers['release_id'] = params.get('release_id');
+            }
+            if (params.has('preview_timestamp')) {
+                this.headers['preview_timestamp'] = params.get('preview_timestamp');
+            }
+        }
+    }
 
     livePreviewQuery(query) {
         if (this.live_preview) {
             this.live_preview.live_preview = query.live_preview || 'init';
             this.live_preview.content_type_uid = query.content_type_uid;
             this.live_preview.entry_uid = query.entry_uid
+        }
+
+        if (query.hasOwnProperty('release_id')) {
+            this.headers['release_id'] = query.release_id;
+        }
+        if (query.hasOwnProperty('preview_timestamp')) {
+            this.headers['preview_timestamp'] = query.preview_timestamp;
         }
     }
 


### PR DESCRIPTION
Adds Timeline Preview changes to SDK
- sets headers from URL when browser is detected
- sets headers from query object when livePreviewQuery function is executed