### PR TITLE
chore: bump @contentstack/utils to 1.9.1 (v3.27.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Change log
 
+### Version: 3.27.1
+#### Date:  Jul-14-2026
+##### Fix:
+ - Update the internal dependency of @contentstack/utils from 1.8.0 to 1.9.1
+
 ### Version: 3.27.0
 #### Date:  Mar-23-2026
 ##### Fix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## Change log
 
-### Version: 3.27.1
+## [3.27.1](https://github.com/contentstack/contentstack-javascript/compare/v3.27.0...v3.27.1)
 #### Date:  Jul-14-2026
 ##### Fix:
- - Update the internal dependency of @contentstack/utils from 1.8.0 to 1.9.1
+ - Bump @contentstack/utils dependency from ^1.4.1 to ^1.9.1
 
 ### Version: 3.27.0
 #### Date:  Mar-23-2026

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "contentstack",
-  "version": "3.27.0",
+  "version": "3.27.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "contentstack",
-      "version": "3.27.0",
+      "version": "3.27.1",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/utils": "^1.4.1",
+        "@contentstack/utils": "^1.9.1",
         "es6-promise": "^4.2.8",
         "husky": "^9.1.7",
         "localStorage": "1.0.4"
@@ -1834,9 +1834,9 @@
       "license": "MIT"
     },
     "node_modules/@contentstack/utils": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@contentstack/utils/-/utils-1.8.0.tgz",
-      "integrity": "sha512-pqCFbn2dynSCW6LUD2AH74LIy32dxxe52OL+HpUxNVXV5doFyClkFjP9toqdAZ81VbCEaOc4WK+VS/RdtMpxDA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@contentstack/utils/-/utils-1.9.1.tgz",
+      "integrity": "sha512-THZM0rNuq0uOSKkKnvzp8lsPDvvdKIvJIcMa9JBv4foL9rC8RWkWffa2yMyb+9m/5HZrdAmpEWdubkGwARa8WQ==",
       "license": "MIT"
     },
     "node_modules/@csstools/color-helpers": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contentstack",
-  "version": "3.27.0",
+  "version": "3.27.1",
   "description": "Contentstack Javascript SDK",
   "homepage": "https://www.contentstack.com/",
   "author": {
@@ -99,7 +99,7 @@
     "webpack-node-externals": "^3.0.0"
   },
   "dependencies": {
-    "@contentstack/utils": "^1.4.1",
+    "@contentstack/utils": "^1.9.1",
     "es6-promise": "^4.2.8",
     "husky": "^9.1.7",
     "localStorage": "1.0.4"


### PR DESCRIPTION
## Summary
- Bump `@contentstack/utils` dependency from `1.8.0` → `1.9.1`
- Release SDK version `3.27.0` → `3.27.1`
- Update CHANGELOG.md with the dependency fix entry

## Context
Follow-up from [DX-8610](https://contentstack.atlassian.net/browse/DX-8610) (internal package version audit). Tracked in [DX-9661](https://contentstack.atlassian.net/browse/DX-9661).

## Test plan
- [x] `npm install` — package-lock.json resolves `@contentstack/utils` to `1.9.1`
- [x] `npm run build` (via `prepare`/webpack) compiles successfully
- [x] `npm run test:typescript` — 153/154 passing (1 pre-existing failure unrelated to this change, requires live stack credentials)
- [ ] `npm run test:e2e` — requires live `HOST`/`API_KEY`/`DELIVERY_TOKEN`/`ENVIRONMENT`, not run locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)